### PR TITLE
Update build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,8 +4,9 @@
 
 # v0.2 - 08 May 2023 - Minor tweaks
 
+# Additional flags added when compiling the binary if you wish to move onto a pod yourself using "kubectl cp" command or via wget if you can on a box
 echo "Building for Linux on AMD64..."
-GOOS=linux GOARCH=amd64 go build -v -ldflags="-s -w" $(realpath ../cmd/peirates)
+GOOS=linux GOARCH=amd64 go build -v -ldflags="-s -w -linkmode 'external' -extldflags '-static'" $(realpath ../cmd/peirates)
 exit_code=$?
 
 if [ $exit_code -eq 0 ] ; then


### PR DESCRIPTION
Change compiler flags so that when you want to deploy the binary onto a container that hasn't been deployed by yourself onto a cluster node, then it is no longer dynamically but staticly linked. 

Works when compiling on Linux (best to compile on the same build variant as container you wish to deploy onto), MacOS cross compilation will present issues, Windows untested.