### PR TITLE
feat: Add support for detecting AWS as a cloud provider when IMDSv2 is in use

### DIFF
--- a/cloud_detection.go
+++ b/cloud_detection.go
@@ -36,7 +36,7 @@ func populateAndCheckCloudProviders() string {
 			HTTPMethod:        "PUT",
 			CustomHeader:      "X-aws-ec2-metadata-token-ttl-seconds",
 			CustomHeaderValue: "21600",
-			ResultString:      "AWS (IMDSv2)"
+			ResultString:      "",
 		},
 		{
 			Name:              "Azure",
@@ -80,14 +80,21 @@ func populateAndCheckCloudProviders() string {
 		fmt.Printf("Checking %s...\n", provider.Name)
 
 		var response string
+		var statusCode int
 
 		var lines []HeaderLine
 		if provider.CustomHeader != "" {
 			line := HeaderLine{LHS: provider.CustomHeader, RHS: provider.CustomHeaderValue}
 			lines = append(lines, line)
-			response = GetRequest(provider.URL, lines, true)
+			response, statusCode = GetRequest(provider.URL, lines, true)
 		} else {
-			response = GetRequest(provider.URL, nil, true)
+			response, statusCode = GetRequest(provider.URL, nil, true)
+		}
+
+		if provider.Name == "AWS (IMDSv2)" {
+			if statusCode == http.StatusOK {
+				return provider.Name
+			}
 		}
 
 		if strings.Contains(response, provider.ResultString) {

--- a/cloud_detection.go
+++ b/cloud_detection.go
@@ -31,6 +31,14 @@ func populateAndCheckCloudProviders() string {
 			ResultString:      "meta-data",
 		},
 		{
+			Name:              "AWS (IMDSv2)",
+			URL:               "http://169.254.169.254/latest/api/token",
+			HTTPMethod:        "PUT",
+			CustomHeader:      "X-aws-ec2-metadata-token-ttl-seconds",
+			CustomHeaderValue: "21600",
+			ResultString:      "AWS (IMDSv2)"
+		},
+		{
 			Name:              "Azure",
 			URL:               "http://169.254.169.254/metadata/v1/InstanceInfo",
 			HTTPMethod:        "GET",
@@ -61,6 +69,7 @@ func populateAndCheckCloudProviders() string {
 		Timeout: 1 * time.Second,
 	}
 	url := "http://169.254.169.254/"
+	// IMDSv2 will return a 401 in this case
 	_, err := client.Get(url)
 	if err != nil {
 		return "-- Public Cloud Provider not detected --"

--- a/exec-via-kubelet-api.go
+++ b/exec-via-kubelet-api.go
@@ -50,7 +50,7 @@ func ExecuteCodeOnKubelet(connectionString ServerInfo, serviceAccounts *[]Servic
 					println("[+] Kubelet Pod Listing URL: " + nodeName + " - " + unauthKubeletPortURL)
 					println("[+] Grabbing Pods from node: " + nodeName)
 
-					runningPodsBody := GetRequest(unauthKubeletPortURL, headers, false)
+					runningPodsBody, _ := GetRequest(unauthKubeletPortURL, headers, false)
 					if (runningPodsBody == "") || (strings.HasPrefix(runningPodsBody, "ERROR:")) {
 						println("[-] Kubelet request for running pods failed - using this URL:", unauthKubeletPortURL)
 						continue nodeLoop

--- a/gcp.go
+++ b/gcp.go
@@ -27,7 +27,7 @@ func GetGCPBearerTokenFromMetadataAPI(account string) (string, time.Time, error)
 	baseURL := "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/"
 	urlSvcAccount := baseURL + account + "/token"
 
-	reqTokenRaw := GetRequest(urlSvcAccount, headers, false)
+	reqTokenRaw, _ := GetRequest(urlSvcAccount, headers, false)
 
 	// TODO: Add a check for a 200 status code
 	if (reqTokenRaw == "") || (strings.HasPrefix(reqTokenRaw, "ERROR:")) {
@@ -92,7 +92,7 @@ func KopsAttackGCP(serviceAccounts *[]ServiceAccount) (err error) {
 	headers = []HeaderLine{
 		HeaderLine{"Metadata-Flavor", "Google"},
 	}
-	projectID := GetRequest("http://metadata.google.internal/computeMetadata/v1/project/numeric-project-id", headers, false)
+	projectID, _ := GetRequest("http://metadata.google.internal/computeMetadata/v1/project/numeric-project-id", headers, false)
 	if (projectID == "") || (strings.HasPrefix(projectID, "ERROR:")) {
 		msg := "[-] Could not get GCP project from metadata API"
 		println(msg)
@@ -108,7 +108,7 @@ func KopsAttackGCP(serviceAccounts *[]ServiceAccount) (err error) {
 
 	// curl -s -H 'Metadata-Flavor: Google' -H "Authorization: Bearer $(cat bearertoken)" -H "Accept: json" https://www.googleapis.com/storage/v1/b/?project=$(cat projectid)
 	urlListBuckets := "https://www.googleapis.com/storage/v1/b/?project=" + projectID
-	bucketListRaw := GetRequest(urlListBuckets, headers, false)
+	bucketListRaw, _ := GetRequest(urlListBuckets, headers, false)
 	if (bucketListRaw == "") || (strings.HasPrefix(bucketListRaw, "ERROR:")) {
 		msg := "[-] blank bucket list or error retriving bucket list"
 		println(msg)
@@ -132,7 +132,7 @@ eachbucket:
 	for _, line := range bucketUrls {
 		println("Checking bucket for credentials:", line)
 		urlListObjects := line + "/o"
-		bodyListObjects := GetRequest(urlListObjects, headers, false)
+		bodyListObjects, _ := GetRequest(urlListObjects, headers, false)
 		if (bodyListObjects == "") || (strings.HasPrefix(bodyListObjects, "ERROR:")) {
 			continue
 		}
@@ -152,7 +152,7 @@ eachbucket:
 					saTokenURL := objectURL + "?alt=media"
 
 					// We use the same headers[] from the previous GET request.
-					bodyToken := GetRequest(saTokenURL, headers, false)
+					bodyToken, _ := GetRequest(saTokenURL, headers, false)
 					if (bodyToken == "") || (strings.HasPrefix(bodyToken, "ERROR:")) {
 						continue eachbucket
 					}

--- a/peirates.go
+++ b/peirates.go
@@ -909,7 +909,7 @@ func Main() {
 				{"Metadata-Flavor", "Google"},
 			}
 			url := "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/"
-			svcAcctListRaw := GetRequest(url, headers, false)
+			svcAcctListRaw, _ := GetRequest(url, headers, false)
 			if (svcAcctListRaw == "") || (strings.HasPrefix(svcAcctListRaw, "ERROR:")) {
 				break
 			}
@@ -940,7 +940,7 @@ func Main() {
 			headers = []HeaderLine{
 				{"Metadata-Flavor", "Google"},
 			}
-			kubeEnv := GetRequest("http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env", headers, false)
+			kubeEnv, _ := GetRequest("http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env", headers, false)
 			if (kubeEnv == "") || (strings.HasPrefix(kubeEnv, "ERROR:")) {
 				println("[-] Error - could not perform request http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env/")
 				// TODO: Should we get error code the way we used to:


### PR DESCRIPTION
This PR adds support for AWS IMDSv2.
<img width="667" alt="Screenshot 2024-04-28 at 11 40 27 AM" src="https://github.com/inguardians/peirates/assets/73837129/569d103f-df53-4790-9f76-dcbe5ac68c9e">


I am not in love with the abstraction and would be willing to alter based on suggestions. I had to change the implementation of GetRequests to return the statusCode, as with IMDSv2, the successful response body ends up being the token used for interacting with IMDSv2, so it felt hacky to rely on just trying to verify it via the body with something like a regex. 

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html